### PR TITLE
install 'gcc-g++' host package

### DIFF
--- a/initial_bootstrap/Dockerfile.fedora
+++ b/initial_bootstrap/Dockerfile.fedora
@@ -2,6 +2,7 @@ FROM fedora:28
 
 RUN dnf check-update || true
 RUN dnf install @development-tools -y
+RUN dnf install gcc-c++ -y
 RUN dnf install sudo -y
 
 # Create user


### PR DESCRIPTION
When we find host gcc version newer than gcc-4.8 we really expect the
C++ compiler to be available as well.