### PR TITLE
need whatever-LATEST to be a real CI build

### DIFF
--- a/initial_bootstrap/Dockerfile
+++ b/initial_bootstrap/Dockerfile
@@ -41,9 +41,9 @@ ENV EPREFIX /tmp/gentoo
 
 # Bootstrap Gentoo Prefix
 # This stops on emerge of gcc-8.2.0-r4, bug #672042
-RUN ./bootstrap-prefix.sh ${EPREFIX} noninteractive
+RUN LATEST_TREE_YES=1 TESTING_PV=latest ./bootstrap-prefix.sh ${EPREFIX} noninteractive
 
-# RUN ./bootstrap-prefix.sh ${EPREFIX} noninteractive || true
+# RUN LATEST_TREE_YES=1 TESTING_PV=latest ./bootstrap-prefix.sh ${EPREFIX} noninteractive || true
 # # To workaround bug #670836
 # # perl error about errno.h and error_t.h
 # RUN cp ${EPREFIX}/usr/include/errno.h ${EPREFIX}/tmp/usr/include/errno.h && mkdir -p ${EPREFIX}/tmp/usr/include/bits/types && cp ${EPREFIX}/usr/include/bits/types/error_t.h ${EPREFIX}/tmp/usr/include/bits/types
@@ -63,13 +63,13 @@ RUN ./bootstrap-prefix.sh ${EPREFIX} noninteractive
 # RUN mkdir ${EPREFIX}/tmp/usr/lib/python-exec/python2.7 && cd ${EPREFIX}/tmp/usr/lib/python-exec/python2.7 && ln -s ../../../bin/python2.7 python2 && ln -s python2 python
 
 # # Let's go again
-# RUN ./bootstrap-prefix.sh ${EPREFIX} noninteractive || true
+# RUN LATEST_TREE_YES=1 TESTING_PV=latest ./bootstrap-prefix.sh ${EPREFIX} noninteractive || true
 
 # # Here perl went thru, so we need to go back to use the system one to avoid
 # # libperl.so.5.26: cannot open shared object file: No such file or directory
 # RUN rm -f ${EPREFIX}/tmp/usr/bin/perl && ln -s /usr/bin/perl ${EPREFIX}/tmp/usr/bin/perl
 
-# RUN ./bootstrap-prefix.sh ${EPREFIX} noninteractive || true
+# RUN LATEST_TREE_YES=1 TESTING_PV=latest ./bootstrap-prefix.sh ${EPREFIX} noninteractive || true
 
 # # Workaround
 # # * Running eautoreconf in '/tmp/gentoo/var/tmp/portage/dev-libs/libgcrypt-1.8.4/work/libgcrypt-1.8.4' ...
@@ -89,19 +89,19 @@ RUN ./bootstrap-prefix.sh ${EPREFIX} noninteractive
 #     ln -s ${EPREFIX}/tmp/usr/bin/autoscan-2.69 ${EPREFIX}/usr/bin/autoscan-2.69 && \
 #     ln -s ${EPREFIX}/tmp/usr/bin/autoupdate-2.69 ${EPREFIX}/usr/bin/autoupdate-2.69
 
-# RUN ./bootstrap-prefix.sh ${EPREFIX} noninteractive || true
+# RUN LATEST_TREE_YES=1 TESTING_PV=latest ./bootstrap-prefix.sh ${EPREFIX} noninteractive || true
 
 # # Workaround for
 # #  * ERROR: app-admin/metalog-20181125::gentoo failed (configure phase):
 # #  *   econf failed
 # RUN mkdir -p ${EPREFIX}/etc/portage/profile && echo "app-admin/metalog-3-r2" >> ${EPREFIX}/etc/portage/profile/package.provided
 
-# RUN ./bootstrap-prefix.sh ${EPREFIX} noninteractive || true
+# RUN LATEST_TREE_YES=1 TESTING_PV=latest ./bootstrap-prefix.sh ${EPREFIX} noninteractive || true
 
 # # On * running emerge -u system
 # # we fall into circular dependencies again, so we do the same we did for ${EPREFIX}/tmp
 # RUN cp ${EPREFIX}/tmp/etc/portage/package.use ${EPREFIX}/etc/portage
 
-# RUN ./bootstrap-prefix.sh ${EPREFIX} noninteractive
+# RUN LATEST_TREE_YES=1 TESTING_PV=latest ./bootstrap-prefix.sh ${EPREFIX} noninteractive
 
 ENTRYPOINT ["/bin/bash"]

--- a/initial_bootstrap/Dockerfile
+++ b/initial_bootstrap/Dockerfile
@@ -41,15 +41,9 @@ ENV EPREFIX /tmp/gentoo
 
 # Bootstrap Gentoo Prefix
 # This stops on emerge of gcc-8.2.0-r4, bug #672042
-RUN echo "Y\n\
-\n\
-${EPREFIX}\n\
-luck\n" | ./bootstrap-prefix.sh
+RUN ./bootstrap-prefix.sh ${EPREFIX} noninteractive
 
-# RUN echo "Y\n\
-# \n\
-# ${EPREFIX}\n\
-# luck\n" | ./bootstrap-prefix.sh || true
+# RUN ./bootstrap-prefix.sh ${EPREFIX} noninteractive || true
 # # To workaround bug #670836
 # # perl error about errno.h and error_t.h
 # RUN cp ${EPREFIX}/usr/include/errno.h ${EPREFIX}/tmp/usr/include/errno.h && mkdir -p ${EPREFIX}/tmp/usr/include/bits/types && cp ${EPREFIX}/usr/include/bits/types/error_t.h ${EPREFIX}/tmp/usr/include/bits/types
@@ -69,19 +63,13 @@ luck\n" | ./bootstrap-prefix.sh
 # RUN mkdir ${EPREFIX}/tmp/usr/lib/python-exec/python2.7 && cd ${EPREFIX}/tmp/usr/lib/python-exec/python2.7 && ln -s ../../../bin/python2.7 python2 && ln -s python2 python
 
 # # Let's go again
-# RUN echo "Y\n\
-# \n\
-# ${EPREFIX}\n\
-# luck\n" | ./bootstrap-prefix.sh || true
+# RUN ./bootstrap-prefix.sh ${EPREFIX} noninteractive || true
 
 # # Here perl went thru, so we need to go back to use the system one to avoid
 # # libperl.so.5.26: cannot open shared object file: No such file or directory
 # RUN rm -f ${EPREFIX}/tmp/usr/bin/perl && ln -s /usr/bin/perl ${EPREFIX}/tmp/usr/bin/perl
 
-# RUN echo "Y\n\
-# \n\
-# ${EPREFIX}\n\
-# luck\n" | ./bootstrap-prefix.sh || true
+# RUN ./bootstrap-prefix.sh ${EPREFIX} noninteractive || true
 
 # # Workaround
 # # * Running eautoreconf in '/tmp/gentoo/var/tmp/portage/dev-libs/libgcrypt-1.8.4/work/libgcrypt-1.8.4' ...
@@ -101,28 +89,19 @@ luck\n" | ./bootstrap-prefix.sh
 #     ln -s ${EPREFIX}/tmp/usr/bin/autoscan-2.69 ${EPREFIX}/usr/bin/autoscan-2.69 && \
 #     ln -s ${EPREFIX}/tmp/usr/bin/autoupdate-2.69 ${EPREFIX}/usr/bin/autoupdate-2.69
 
-# RUN echo "Y\n\
-# \n\
-# ${EPREFIX}\n\
-# luck\n" | ./bootstrap-prefix.sh || true
+# RUN ./bootstrap-prefix.sh ${EPREFIX} noninteractive || true
 
 # # Workaround for
 # #  * ERROR: app-admin/metalog-20181125::gentoo failed (configure phase):
 # #  *   econf failed
 # RUN mkdir -p ${EPREFIX}/etc/portage/profile && echo "app-admin/metalog-3-r2" >> ${EPREFIX}/etc/portage/profile/package.provided
 
-# RUN echo "Y\n\
-# \n\
-# ${EPREFIX}\n\
-# luck\n" | ./bootstrap-prefix.sh || true
+# RUN ./bootstrap-prefix.sh ${EPREFIX} noninteractive || true
 
 # # On * running emerge -u system
 # # we fall into circular dependencies again, so we do the same we did for ${EPREFIX}/tmp
 # RUN cp ${EPREFIX}/tmp/etc/portage/package.use ${EPREFIX}/etc/portage
 
-# RUN echo "Y\n\
-# \n\
-# ${EPREFIX}\n\
-# luck\n" | ./bootstrap-prefix.sh
+# RUN ./bootstrap-prefix.sh ${EPREFIX} noninteractive
 
 ENTRYPOINT ["/bin/bash"]

--- a/initial_bootstrap/Dockerfile.fedora
+++ b/initial_bootstrap/Dockerfile.fedora
@@ -26,7 +26,7 @@ RUN curl -O https://gitweb.gentoo.org/repo/proj/prefix.git/plain/scripts/bootstr
 RUN chmod +x bootstrap-prefix.sh
 
 # Bootstrap Gentoo Prefix
-RUN PREFIX_DISABLE_RAP=yes ./bootstrap-prefix.sh /tmp/gentoo noninteractive
+RUN PREFIX_DISABLE_RAP=yes LATEST_TREE_YES=1 TESTING_PV=latest ./bootstrap-prefix.sh /tmp/gentoo noninteractive
 
 
 ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
Without LATEST, we would test the bootstrap script only - which may make sense by itself, but we leave the chance to find a point in time for taking another tree snapshot which should work in multiple situations.
And the 'noninteractive' mode also does work for RAP.